### PR TITLE
Add ability to pass input dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,15 @@ Then run with:
 t4s
 ```
 
+### Pass input directory
+
+You can pass an input path a Strapi `src` directory e.g
+
+```bash
+# Inside "./packages/frontend"
+t4s ../backend/src
+```
+
 ## Attributes
 
 For some inscrutable reason, Strapi 4 returns objects where all the properties (aside from `id`) are wrapped into an `attributes` object. The resulting interfaces will look like this:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "types-4-strapi",
-  "version": "1.0.22",
+  "version": "1.1.0",
   "description": "Typescript interface generator for Strapi 4 models",
   "main": "./src/index.js",
   "bin": {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,3 +1,5 @@
+const fs = require('fs');
+
 module.exports.pascalCase = (str) => {
   if (!str) return;
   const words = str.match(/[a-z]+/gi);
@@ -14,4 +16,9 @@ module.exports.isOptional = (attributeValue) => {
     return false;
   }
   return attributeValue.required !== true;
+};
+
+module.exports.createFile = (filePath, data) => {
+  console.log(`Creating: ${filePath}`);
+  fs.writeFileSync(filePath, data);
 };


### PR DESCRIPTION
Hey @francescolorenzetti 👋 

Thanks for the great package, here's a little PR that allows you to pass a path to the strapi `src` directory.

At the moment we are running `t4s` inside our strapi directory, then manually copying the types directory over to our frontend directory, (we're using yarn workspaces so think `./packages/backend` and `.packages/frontend` so this allows us to run `t4s` in our frontend directory, and have the types created there instead.

Also added a little util [createFile](https://github.com/studio-206/types-4-strapi/blob/feat/add-ability-to-pass-input-dir/src/utils.js#L21-L24) function to have some visual feedback of what's happening for dev experience:

```
😎 ➡️  ~/code/studio206/ampersand/packages/frontend git:(main) ✗ yarn t4s ../backend/src
yarn run v1.22.18
$ t4s ../backend/src
Creating: types/Payload.ts
Creating: types/User.ts
Creating: types/MediaFormat.ts
Creating: types/Media.ts
Creating: types/Building.ts
Creating: types/FeatureFlag.ts
Creating: types/components/DesignStyles.ts
Creating: types/components/Floor.ts
✨  Done in 0.46s.
```