### PR TITLE
feat: generating flattened types

### DIFF
--- a/src/createComponentInterface.js
+++ b/src/createComponentInterface.js
@@ -37,7 +37,7 @@ module.exports = (schemaPath, interfaceName) => {
         });
       const isArray = attributeValue.relation === 'oneToMany';
       const bracketsIfArray = isArray ? '[]' : '';
-      tsProperty = `  ${attributeName}: { data: ${tsType}${bracketsIfArray} };\n`;
+      tsProperty = `  ${attributeName}: ${tsType}${bracketsIfArray};\n`;
     }
     // -------------------------------------------------
     // Component
@@ -68,9 +68,9 @@ module.exports = (schemaPath, interfaceName) => {
           type: tsType,
           path: tsImportPath,
         });
-      tsProperty = `  ${attributeName}: { data: ${tsType}${
+      tsProperty = `  ${attributeName}: ${tsType}${
         attributeValue.multiple ? '[]' : ''
-      } };\n`;
+      };\n`;
     }
     // -------------------------------------------------
     // Enumeration

--- a/src/createInterface.js
+++ b/src/createInterface.js
@@ -37,7 +37,7 @@ module.exports = (schemaPath, interfaceName) => {
         });
       const isArray = attributeValue.relation.endsWith('ToMany');
       const bracketsIfArray = isArray ? '[]' : '';
-      tsProperty = `  ${attributeName}: { data: ${tsPropertyType}${bracketsIfArray} };\n`;
+      tsProperty = `  ${attributeName}: ${tsPropertyType}${bracketsIfArray};\n`;
     }
     // -------------------------------------------------
     // Component
@@ -76,9 +76,9 @@ module.exports = (schemaPath, interfaceName) => {
           type: tsPropertyType,
           path: tsImportPath,
         });
-      tsProperty = `  ${attributeName}: { data: ${tsPropertyType}${
+      tsProperty = `  ${attributeName}: ${tsPropertyType}${
         attributeValue.multiple ? '[]' : ''
-      } };\n`;
+      };\n`;
     }
     // -------------------------------------------------
     // Enumeration

--- a/src/createInterface.js
+++ b/src/createInterface.js
@@ -6,7 +6,6 @@ module.exports = (schemaPath, interfaceName) => {
   var tsInterface = `\n`;
   tsInterface += `export interface ${interfaceName} {\n`;
   tsInterface += `  id: number;\n`;
-  tsInterface += `  attributes: {\n`;
   var schemaFile;
   var schema;
   try {
@@ -38,7 +37,7 @@ module.exports = (schemaPath, interfaceName) => {
         });
       const isArray = attributeValue.relation.endsWith('ToMany');
       const bracketsIfArray = isArray ? '[]' : '';
-      tsProperty = `    ${attributeName}: { data: ${tsPropertyType}${bracketsIfArray} };\n`;
+      tsProperty = `  ${attributeName}: { data: ${tsPropertyType}${bracketsIfArray} };\n`;
     }
     // -------------------------------------------------
     // Component
@@ -56,7 +55,7 @@ module.exports = (schemaPath, interfaceName) => {
         });
       const isArray = attributeValue.repeatable;
       const bracketsIfArray = isArray ? '[]' : '';
-      tsProperty = `    ${attributeName}: ${tsPropertyType}${bracketsIfArray};\n`;
+      tsProperty = `  ${attributeName}: ${tsPropertyType}${bracketsIfArray};\n`;
     }
     // -------------------------------------------------
     // Dynamic zone
@@ -64,7 +63,7 @@ module.exports = (schemaPath, interfaceName) => {
     else if (attributeValue.type === 'dynamiczone') {
       // TODO
       tsPropertyType = 'any';
-      tsProperty = `    ${attributeName}: ${tsPropertyType};\n`;
+      tsProperty = `  ${attributeName}: ${tsPropertyType};\n`;
     }
     // -------------------------------------------------
     // Media
@@ -77,7 +76,7 @@ module.exports = (schemaPath, interfaceName) => {
           type: tsPropertyType,
           path: tsImportPath,
         });
-      tsProperty = `    ${attributeName}: { data: ${tsPropertyType}${
+      tsProperty = `  ${attributeName}: { data: ${tsPropertyType}${
         attributeValue.multiple ? '[]' : ''
       } };\n`;
     }
@@ -86,7 +85,7 @@ module.exports = (schemaPath, interfaceName) => {
     // -------------------------------------------------
     else if (attributeValue.type === 'enumeration') {
       const enumOptions = attributeValue.enum.map((v) => `'${v}'`).join(' | ');
-      tsProperty = `    ${attributeName}: ${enumOptions};\n`;
+      tsProperty = `  ${attributeName}: ${enumOptions};\n`;
     }
     // -------------------------------------------------
     // Text, RichText, Email, UID
@@ -99,14 +98,14 @@ module.exports = (schemaPath, interfaceName) => {
       attributeValue.type === 'uid'
     ) {
       tsPropertyType = 'string';
-      tsProperty = `    ${attributeName}: ${tsPropertyType};\n`;
+      tsProperty = `  ${attributeName}: ${tsPropertyType};\n`;
     }
     // -------------------------------------------------
     // Json
     // -------------------------------------------------
     else if (attributeValue.type === 'json') {
       tsPropertyType = 'any';
-      tsProperty = `    ${attributeName}: ${tsPropertyType};\n`;
+      tsProperty = `  ${attributeName}: ${tsPropertyType};\n`;
     }
     // -------------------------------------------------
     // Password
@@ -124,7 +123,7 @@ module.exports = (schemaPath, interfaceName) => {
       attributeValue.type === 'float'
     ) {
       tsPropertyType = 'number';
-      tsProperty = `    ${attributeName}: ${tsPropertyType};\n`;
+      tsProperty = `  ${attributeName}: ${tsPropertyType};\n`;
     }
     // -------------------------------------------------
     // Date
@@ -135,21 +134,21 @@ module.exports = (schemaPath, interfaceName) => {
       attributeValue.type === 'time'
     ) {
       tsPropertyType = 'Date';
-      tsProperty = `    ${attributeName}: ${tsPropertyType};\n`;
+      tsProperty = `  ${attributeName}: ${tsPropertyType};\n`;
     }
     // -------------------------------------------------
     // Boolean
     // -------------------------------------------------
     else if (attributeValue.type === 'boolean') {
       tsPropertyType = 'boolean';
-      tsProperty = `    ${attributeName}: ${tsPropertyType};\n`;
+      tsProperty = `  ${attributeName}: ${tsPropertyType};\n`;
     }
     // -------------------------------------------------
     // Others
     // -------------------------------------------------
     else {
       tsPropertyType = 'any';
-      tsProperty = `    ${attributeName}: ${tsPropertyType};\n`;
+      tsProperty = `  ${attributeName}: ${tsPropertyType};\n`;
     }
     tsInterface += tsProperty;
   }
@@ -160,7 +159,6 @@ module.exports = (schemaPath, interfaceName) => {
     tsInterface += `    locale: string;\n`;
     tsInterface += `    localizations?: { data: ${interfaceName}[] }\n`;
   }
-  tsInterface += `  }\n`;
   tsInterface += '}\n';
   for (const tsImport of tsImports) {
     tsInterface =

--- a/src/index.js
+++ b/src/index.js
@@ -34,15 +34,13 @@ fs.writeFileSync(`${typesDir}/Payload.ts`, payloadTsInterface);
 
 const userTsInterface = `export interface User {
   id: number;
-  attributes: {
-    username: string;
-    email: string;
-    provider: string;
-    confirmed: boolean;
-    blocked: boolean;
-    createdAt: Date;
-    updatedAt: Date;
-  }
+  username: string;
+  email: string;
+  provider: string;
+  confirmed: boolean;
+  blocked: boolean;
+  createdAt: Date;
+  updatedAt: Date;
 }
 `;
 
@@ -75,23 +73,21 @@ var mediaTsInterface = `import { MediaFormat } from './MediaFormat';
 
 export interface Media {
   id: number;
-  attributes: {
-    name: string;
-    alternativeText: string;
-    caption: string;
-    width: number;
-    height: number;
-    formats: { thumbnail: MediaFormat; medium: MediaFormat; small: MediaFormat; };
-    hash: string;
-    ext: string;
-    mime: string;
-    size: number;
-    url: string;
-    previewUrl: string;
-    provider: string;
-    createdAt: Date;
-    updatedAt: Date;
-  }
+  name: string;
+  alternativeText: string;
+  caption: string;
+  width: number;
+  height: number;
+  formats: { thumbnail: MediaFormat; medium: MediaFormat; small: MediaFormat; };
+  hash: string;
+  ext: string;
+  mime: string;
+  size: number;
+  url: string;
+  previewUrl: string;
+  provider: string;
+  createdAt: Date;
+  updatedAt: Date;
 }
 `;
 


### PR DESCRIPTION
After doing some research and dealing with all the `data` & `attributes` boilerplate added by strapi automatically I found a way to flatten the data and tweaked a little bit to handle errors in this gist:

[Flatten Api Responses](https://gist.github.com/zimoo354/09bc7908a3c59982f0f593a72996cf6c)

And then made some tweaks to the `t4s` command so it matches the flattened version of the response.